### PR TITLE
Make documentation consistent with function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 ### `turf.convex(input)`
 
-Takes a FeatureCollection of Point features and
-returns a [convex hull](http://en.wikipedia.org/wiki/Convex_hull) polygon.
+Takes any GeoJSON object and returns a 
+[convex hull](http://en.wikipedia.org/wiki/Convex_hull) polygon.
 
 Internally this implements
 a [Monotone chain algorithm](http://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain#JavaScript).

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var each = require('turf-meta').coordEach;
 // http://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain#JavaScript
 
 /**
- * Takes a {@link FeatureCollection} of {@link Point} features and
- * returns a [convex hull](http://en.wikipedia.org/wiki/Convex_hull) polygon.
+ * Takes any {@link GeoJSON} object and returns a 
+ * [convex hull](http://en.wikipedia.org/wiki/Convex_hull) polygon.
  *
  * Internally this implements
  * a [Monotone chain algorithm](http://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain#JavaScript).


### PR DESCRIPTION
Documentation used to imply that you could only pass a FeatureCollection of Points.