### PR TITLE
[Fix] If the hull is empty, return a null polygon instead of crashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,10 +78,15 @@ module.exports = function(fc) {
   var points = [];
   each(fc, function(coord) { points.push(coord); });
   var hull = convexHull(points);
-  var ring = [];
-  for (var i = 0; i < hull.length; i++) {
-      ring.push(points[hull[i][0]]);
+
+  if (hull.length > 0) {
+    var ring = [];
+    for (var i = 0; i < hull.length; i++) {
+        ring.push(points[hull[i][0]]);
+    }
+    ring.push(points[hull[hull.length - 1][1]]);
+    return polygon([ring]);
   }
-  ring.push(points[hull[hull.length - 1][1]]);
-  return polygon([ring]);
+
+  return null;
 };


### PR DESCRIPTION
When the created hull is empty, which is the case when all the points are at the same position, turf-convex crashes.

Instead, we return null.
